### PR TITLE
fix: カードがないときの表示を修正

### DIFF
--- a/lib/views/widgets/cards_list.dart
+++ b/lib/views/widgets/cards_list.dart
@@ -13,44 +13,66 @@ class CardsList extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     List<String> exchangedCards = ref.watch(exchangedCardsProvider);
 
-    return Expanded(
-      child: ListView.builder(
-        itemCount: exchangedCards.length + 2,
-        itemBuilder: (context, index) {
-          if (index == 0) {
-            return const SizedBox(height: 16);
-          }
-          if (index == exchangedCards.length + 1) {
-            return const SizedBox(height: 80);
-          }
-          return Column(
-            children: [
-              GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTap: () {
-                  Navigator.of(context).push(MaterialPageRoute(
-                    builder: (context) => CardDetails(
-                      cardId: exchangedCards[index - 1],
+    return (exchangedCards.isNotEmpty)
+        ? Expanded(
+            child: ListView.builder(
+              itemCount: exchangedCards.length + 2,
+              itemBuilder: (context, index) {
+                if (index == 0) {
+                  return const SizedBox(height: 16);
+                }
+                if (index == exchangedCards.length + 1) {
+                  return const SizedBox(height: 80);
+                }
+                return Column(
+                  children: [
+                    GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: () {
+                        Navigator.of(context).push(MaterialPageRoute(
+                          builder: (context) => CardDetails(
+                            cardId: exchangedCards[index - 1],
+                          ),
+                        ));
+                      },
+                      child: ConstrainedBox(
+                        constraints: const BoxConstraints(
+                          maxHeight: 400,
+                        ),
+                        child: FittedBox(
+                          child: MyCard(
+                            cardId: exchangedCards[index - 1],
+                            cardType: CardType.normal,
+                          ),
+                        ),
+                      ),
                     ),
-                  ));
-                },
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(
-                    maxHeight: 400,
-                  ),
-                  child: FittedBox(
-                    child: MyCard(
-                      cardId: exchangedCards[index - 1],
-                      cardType: CardType.normal,
-                    ),
-                  ),
+                    const SizedBox(height: 24),
+                  ],
+                );
+              },
+            ),
+          )
+        : Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.priority_high_rounded,
+                  size: 120,
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onBackground
+                      .withOpacity(0.3),
                 ),
-              ),
-              const SizedBox(height: 24),
-            ],
+                const SizedBox(height: 20),
+                Text(
+                  'まだカードがありません',
+                  style: TextStyle(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant),
+                ),
+              ],
+            ),
           );
-        },
-      ),
-    );
   }
 }


### PR DESCRIPTION
### Issue 番号

<!-- 関連する Issue の番号を記入します。 -->

- Close #595

### 変更内容

<!-- この PR の変更内容を説明します。 -->

- カードが0枚のときの条件分岐を復元
- 「カードがありません」の表示の復元

### この PR はマージ可能な状態ですか

<!-- 当てはまるもの 1 つに「x」をマークします。 -->

```
[x] Yes
[ ] No
```

### 確認事項

@keigomichi

- [x] カードが0枚のときの、条件式および表示内容を確認する

### その他

<!-- その他の付言したい情報等を記入します。 -->

-
